### PR TITLE
A shot in the dark based on the exceptions in Insights

### DIFF
--- a/Sensus.iOS/iOSSensusServiceHelper.cs
+++ b/Sensus.iOS/iOSSensusServiceHelper.cs
@@ -136,10 +136,11 @@ namespace Sensus.iOS
             {
                 UILocalNotification notification = new UILocalNotification
                 {
-                    FireDate = DateTime.UtcNow.AddMilliseconds((double)delayMS).ToNSDate(),
-                    TimeZone = null,  // null for UTC interpretation of FireDate
-                    AlertBody = userNotificationMessage,
-                    UserInfo = GetNotificationUserInfoDictionary(callbackId, repeating, repeatDelayMS, repeatLag, notificationId)
+                    FireDate   = DateTime.UtcNow.AddMilliseconds(delayMS).ToNSDate(),
+                    TimeZone   = null,  // null for UTC interpretation of FireDate
+                    AlertTitle = "Sensus",
+                    AlertBody  = userNotificationMessage,
+                    UserInfo   = GetNotificationUserInfoDictionary(callbackId, repeating, repeatDelayMS, repeatLag, notificationId)
                 };
 
                 // user info can be null if we don't have an activation ID. don't schedule the notification if this happens.


### PR DESCRIPTION
We have some users reporting that they don't receive surveys. [These](https://insights.xamarin.com/app/Sensus-Production/issues/1219) exceptions in Insights appear to be related. We thought this was all related to the bands because the last log entry on phones with this issue is usually related to the bands. However, upon further investigation, it appears there is a confounding variable behind the bands (i.e. the notifications that bring the Sensus into the foreground). 

With all that said, I have no idea why this code would only break some phones rather than all iPhones. Still this seems to be the most likely cause to me given the exception message in Insight. Without an exact line number it is hard to say though.

Should close #258