### PR TITLE
#829 ios timer based callbacks

### DIFF
--- a/Sensus.Shared/Callbacks/CallbackScheduler.cs
+++ b/Sensus.Shared/Callbacks/CallbackScheduler.cs
@@ -50,7 +50,7 @@ namespace Sensus.Callbacks
         protected abstract Task RequestLocalInvocationAsync(ScheduledCallback callback);
         protected abstract void CancelLocalInvocation(ScheduledCallback callback);
 
-        public async Task<ScheduledCallbackState> ScheduleCallbackAsync(ScheduledCallback callback)
+        public virtual async Task<ScheduledCallbackState> ScheduleCallbackAsync(ScheduledCallback callback)
         {
             // the next execution time is computed from the time the current method is called, as the
             // caller may hang on to the ScheduledCallback for some time before calling the current method.
@@ -76,10 +76,6 @@ namespace Sensus.Callbacks
                 callback.State = ScheduledCallbackState.Scheduled;
 
                 await RequestLocalInvocationAsync(callback);
-
-#if __IOS__
-                await RequestRemoteInvocationAsync(callback);
-#endif
             }
             else
             {
@@ -306,7 +302,7 @@ namespace Sensus.Callbacks
                                 await RequestLocalInvocationAsync(callback);
 
 #if __IOS__
-                                await RequestRemoteInvocationAsync(callback);
+                                //await RequestRemoteInvocationAsync(callback);
 #endif
                             }
                             else
@@ -335,7 +331,7 @@ namespace Sensus.Callbacks
         /// </summary>
         /// <returns>Task.</returns>
         /// <param name="callback">Callback.</param>
-        private async Task RequestRemoteInvocationAsync(ScheduledCallback callback)
+        protected async Task RequestRemoteInvocationAsync(ScheduledCallback callback)
         {
             // not all callbacks are associated with a protocol (e.g., the app-level health test). because push notifications are
             // currently tied to the remote data store of the protocol, we don't currently provide PNR support for such callbacks.
@@ -372,7 +368,7 @@ namespace Sensus.Callbacks
             }
         }
 
-        private async Task CancelRemoteInvocationAsync(ScheduledCallback callback)
+        protected async Task CancelRemoteInvocationAsync(ScheduledCallback callback)
         {
             await SensusContext.Current.Notifier.DeletePushNotificationRequestAsync(callback.PushNotificationBackendKey, callback.Protocol, CancellationToken.None);
         }

--- a/Sensus.Shared/Callbacks/ScheduledCallback.cs
+++ b/Sensus.Shared/Callbacks/ScheduledCallback.cs
@@ -185,6 +185,7 @@ namespace Sensus.Callbacks
         /// <param name="timeout">How long to allow callback to execute before cancelling it.</param>
         /// <param name="delayToleranceBefore">Delay tolerance before.</param>
         /// <param name="delayToleranceAfter">Delay tolerance after.</param>
+        /// <param name="priority">The priority of the callback.</param>
         public ScheduledCallback(ActionAsyncDelegate actionAsync,
                                  TimeSpan delay,
                                  string id,
@@ -218,6 +219,7 @@ namespace Sensus.Callbacks
         /// <param name="timeout">How long to allow callback to execute before cancelling it.</param>
         /// <param name="delayToleranceBefore">Delay tolerance before.</param>
         /// <param name="delayToleranceAfter">Delay tolerance after.</param>
+        /// <param name="priority">The priority of the callback.</param>
         public ScheduledCallback(ActionAsyncDelegate actionAsync,
                                  TimeSpan initialDelay,
                                  TimeSpan repeatDelay,

--- a/Sensus.iOS.Shared/Callbacks/iOSTimerCallbackScheduler.cs
+++ b/Sensus.iOS.Shared/Callbacks/iOSTimerCallbackScheduler.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Foundation;
+using Sensus.Callbacks;
+using Sensus.Context;
+using Sensus.iOS.Notifications.UNUserNotifications;
+using UserNotifications;
+
+namespace Sensus.iOS.Callbacks
+{
+	public class iOSTimerCallbackScheduler : iOSCallbackScheduler
+	{
+		private Dictionary<string, NSTimer> _timers;
+
+		public iOSTimerCallbackScheduler()
+		{
+			_timers = new Dictionary<string, NSTimer>();
+		}
+
+		public override List<string> CallbackIds
+		{
+			get
+			{
+				List<string> callbackIds;
+
+				lock (_timers)
+				{
+					callbackIds = _timers.Keys.ToList();
+				}
+
+				return callbackIds;
+			}
+		}
+
+		public override void CancelSilentNotifications()
+		{
+			throw new NotImplementedException();
+		}
+
+		protected override void CancelLocalInvocation(ScheduledCallback callback)
+		{
+			SensusContext.Current.MainThreadSynchronizer.ExecuteThreadSafe(() =>
+			{
+				lock (_timers)
+				{
+					if (_timers.TryGetValue(callback.Id, out NSTimer timer))
+					{
+						timer.Invalidate();
+
+						_timers.Remove(callback.Id);
+					}
+				}
+			});
+		}
+
+		protected override Task ReissueSilentNotificationAsync(string id)
+		{
+			throw new NotImplementedException();
+		}
+
+		protected override async Task RequestLocalInvocationAsync(ScheduledCallback callback)
+		{
+			if (callback.RepeatDelay != null && callback.NextExecution != null)
+			{
+				if (_timers.TryGetValue(callback.Id, out NSTimer existingTimer) == false || existingTimer.TimeInterval != callback.RepeatDelay?.TotalSeconds)
+				{
+					CancelLocalInvocation(callback);
+
+					await SensusContext.Current.MainThreadSynchronizer.ExecuteThreadSafe(async () =>
+					{
+						NSTimer timer = new NSTimer((NSDate)callback.NextExecution.Value, callback.RepeatDelay.Value, async t =>
+						{
+
+							await RaiseCallbackAsync(callback, callback.InvocationId);
+
+						}, true);
+						/*{
+							Tolerance = callback.RepeatDelay.Value.TotalMilliseconds * .10
+						};*/
+
+						NSRunLoop.Main.AddTimer(timer, NSRunLoopMode.Default);
+
+						lock (_timers)
+						{
+							_timers[callback.Id] = timer;
+						}
+
+					});
+				}
+			}
+
+			await Task.CompletedTask;
+		}
+
+		public async Task RequestNotificationsAsync()
+		{
+			UNUserNotificationNotifier notifier = SensusContext.Current.Notifier as UNUserNotificationNotifier;
+
+			foreach (string id in CallbackIds)
+			{
+				if (TryGetCallback(id) is ScheduledCallback callback)
+				{
+					using (NSMutableDictionary callbackInfo = GetCallbackInfo(callback))
+					{
+						if (callbackInfo != null)
+						{
+							if (callback.Silent)
+							{
+								await notifier.IssueSilentNotificationAsync(callback.Id, callback.NextExecution.Value, callbackInfo);
+							}
+							else
+							{
+								await notifier.IssueNotificationAsync(callback.Protocol?.Name ?? "Alert", callback.UserNotificationMessage, callback.Id, true, callback.Protocol, null, callback.NotificationUserResponseAction, callback.NotificationUserResponseMessage, callback.NextExecution.Value, callbackInfo);
+							}
+
+							await RequestRemoteInvocationAsync(callback);
+						}
+					}
+				}
+			}
+		}
+
+		public async Task CancelNotificationsAsync()
+		{
+			UNUserNotificationNotifier notifier = SensusContext.Current.Notifier as UNUserNotificationNotifier;
+
+			foreach (string id in CallbackIds)
+			{
+				if (TryGetCallback(id) is ScheduledCallback callback)
+				{
+					notifier.CancelNotification(callback.Id);
+
+					await CancelRemoteInvocationAsync(callback);
+				}
+			}
+		}
+	}
+}

--- a/Sensus.iOS.Shared/Sensus.iOS.Shared.projitems
+++ b/Sensus.iOS.Shared/Sensus.iOS.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Sensus.iOS</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Callbacks\iOSTimerCallbackScheduler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Concurrent\MainConcurrent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Context\iOSSensusContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Probes\Apps\iOSCalendarProbe.cs" />
@@ -56,7 +57,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Probes\Location\EstimoteForegroundIndoorLocationManagerDelegate.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="$(MSBuildThisFileDirectory)Callbacks\" />
     <Folder Include="$(MSBuildThisFileDirectory)UI\" />
     <Folder Include="$(MSBuildThisFileDirectory)Notifications\" />
     <Folder Include="$(MSBuildThisFileDirectory)Notifications\UNUserNotifications\" />

--- a/Sensus.iOS/AppDelegate.cs
+++ b/Sensus.iOS/AppDelegate.cs
@@ -33,6 +33,9 @@ using Sensus.Encryption;
 using System.Threading;
 using Sensus.iOS.Notifications;
 using Sensus.Notifications;
+using System.Collections.Generic;
+using System.Linq;
+using Sensus.Probes.Location;
 
 namespace Sensus.iOS
 {
@@ -56,7 +59,7 @@ namespace Sensus.iOS
                 PowerConnectionChangeListener = new iOSPowerConnectionChangeListener()
             };
 
-            SensusContext.Current.CallbackScheduler = new UNUserNotificationCallbackScheduler();
+            SensusContext.Current.CallbackScheduler = new iOSTimerCallbackScheduler(); // new UNUserNotificationCallbackScheduler();
             SensusContext.Current.Notifier = new UNUserNotificationNotifier();
             UNUserNotificationCenter.Current.Delegate = new UNUserNotificationDelegate();
 
@@ -231,6 +234,12 @@ namespace Sensus.iOS
                     // update/run all callbacks
                     await (SensusContext.Current.CallbackScheduler as iOSCallbackScheduler).UpdateCallbacksOnActivationAsync();
 
+                    // If the callback scheduler is timer-based then we don't need remote notifications now that the app is activated
+                    if (SensusContext.Current.CallbackScheduler is iOSTimerCallbackScheduler scheduler)
+                    {
+                        await scheduler.CancelNotificationsAsync();
+                    }
+
                     // disabling notifications will greatly impair the user's studies. let the user know.
                     if (!notificationsAuthorized)
                     {
@@ -381,10 +390,21 @@ namespace Sensus.iOS
 
             iOSSensusServiceHelper serviceHelper = SensusServiceHelper.Get() as iOSSensusServiceHelper;
 
-            // cancel all silent notifications, which should never be presented to the user. if these notifications
-            // are not cancelled and the app enters the background, then they will appear in the notification 
-            // tray and confuse the user.
-            (SensusContext.Current.CallbackScheduler as iOSCallbackScheduler).CancelSilentNotifications();
+            // if the callback scheduler is timer-based and gps is not running then we need to request remote notifications
+            if (SensusContext.Current.CallbackScheduler is iOSTimerCallbackScheduler scheduler)
+            {
+                if (SensusServiceHelper.Get().GetRunningProtocols().SelectMany(x => x.Probes).OfType<ListeningLocationProbe>().Any(x => x.Enabled) == false)
+                {
+                    await scheduler.RequestNotificationsAsync();
+                }
+            }
+            else // otherwise do what the callback scheduler used to do
+            {
+                // cancel all silent notifications, which should never be presented to the user. if these notifications
+                // are not cancelled and the app enters the background, then they will appear in the notification 
+                // tray and confuse the user.
+                (SensusContext.Current.CallbackScheduler as iOSCallbackScheduler).CancelSilentNotifications();
+            }
 
             // save app state
             await serviceHelper.SaveAsync();


### PR DESCRIPTION
#829 Timers are now used for the callbacks on iOS. When the app gets backgrounded with a LocationListeningProbe active in any protocol then the timers continue handling the callbacks and no notifications are requested or shown to the user. If the probe is not active, then the notifications are added and their handling (hopefully!) works just like it did originally.

A couple things to consider are that the timers can have a tolerance, but when I added that it made them pretty inaccurate. 10% or 1.5s on a 15s timer caused it to be delayed by up to 5s. But that can supposedly help with power consumption, so we can keep an eye on it. There is also another timer mechanism based on the Grand Central Dispatch system in iOS, but there didn't seem to be much advantage to using that other than it being newer than the NSTimer class.