### PR TITLE
#893 Regex anonymizers

### DIFF
--- a/Sensus.Shared/Anonymization/Anonymizers/Anonymizer.cs
+++ b/Sensus.Shared/Anonymization/Anonymizers/Anonymizer.cs
@@ -33,6 +33,14 @@ namespace Sensus.Anonymization.Anonymizers
         /// <param name="protocol">Protocol that owns the datum being anonymized.</param>
         public abstract object Apply(object value, Protocol protocol);
 
+		public bool IsValid => Validate(out string _);
+		public virtual bool Validate(out string errorMessage)
+		{
+			errorMessage = null;
+
+			return true;
+		}
+
         public override bool Equals(object obj)
         {
             if (obj == null)

--- a/Sensus.Shared/Anonymization/Anonymizers/RegExAnonymizer.cs
+++ b/Sensus.Shared/Anonymization/Anonymizers/RegExAnonymizer.cs
@@ -1,0 +1,64 @@
+﻿using Sensus.UI.UiProperties;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Sensus.Anonymization.Anonymizers
+{
+	public class RegExAnonymizer : Anonymizer
+	{
+		public string DEFAULT_REPLACEMENT = "\u2588";
+
+		public override string DisplayText => "RegEx Anonymizer";
+
+		[EntryStringUiProperty("Pattern:", true, 1, true)]
+		public string Pattern { get; set; }
+		[EntryStringUiProperty("Replacement:", true, 1, true)]
+		public string Replacement { get; set; }
+
+		public RegExAnonymizer()
+		{
+			Replacement = DEFAULT_REPLACEMENT;
+		}
+
+		public override object Apply(object value, Protocol protocol)
+		{
+			if (value is string stringValue)
+			{
+				return Regex.Replace(stringValue, Pattern, m =>
+				{
+					return string.Join("", Enumerable.Repeat(Replacement, m.Value.Length));
+				});
+			}
+
+			return value;
+		}
+
+		public override bool Validate(out string errorMessage)
+		{
+			errorMessage = null;
+
+			if (string.IsNullOrEmpty(Pattern))
+			{
+				errorMessage = "Pattern is required.";
+
+				return false;
+			}
+
+			try
+			{
+				Regex regex = new Regex(Pattern);
+			}
+			catch (Exception error)
+			{
+				errorMessage = error.Message;
+
+				return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/Sensus.Shared/Probes/Apps/KeystrokeDatum.cs
+++ b/Sensus.Shared/Probes/Apps/KeystrokeDatum.cs
@@ -50,7 +50,7 @@ namespace Sensus.Probes.Apps
 		/// The key pressed.
 		/// </summary>
 		[StringProbeTriggerProperty]
-        [Anonymizable(null, typeof(StringHashAnonymizer), false)]
+        [Anonymizable(null, new[] { typeof(StringHashAnonymizer), typeof(RegExAnonymizer) }, -1)]
         public string Key { get => _key; set => _key = value; }
 
 		/// <summary>

--- a/Sensus.Shared/Sensus.Shared.projitems
+++ b/Sensus.Shared/Sensus.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Anonymization\Anonymizers\LongitudeStudyOffsetGpsAnonymizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Anonymization\Anonymizers\LongitudeParticipantOffsetGpsAnonymizer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Anonymization\Anonymizers\RegExAnonymizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Callbacks\ScheduledCallbackPriorities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Concurrent\ConcurrentObservableCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Concurrent\IConcurrent.cs" />
@@ -159,6 +160,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Probes\User\Scripts\RunMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\AddProximityTriggerPage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\AddScriptTriggerPage.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\AnonymizerPage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\App.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\DataStorePage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\Inputs\TimeInput.cs" />

--- a/Sensus.Shared/UI/AnonymizerPage.cs
+++ b/Sensus.Shared/UI/AnonymizerPage.cs
@@ -1,0 +1,119 @@
+﻿using Newtonsoft.Json;
+using Sensus.Anonymization.Anonymizers;
+using Sensus.Context;
+using Sensus.UI.UiProperties;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+
+namespace Sensus.UI
+{
+	public class AnonymizerPage : ContentPage
+	{
+		private readonly Anonymizer _anonymizer;
+		private readonly string _serializedAnonymizer;
+		private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
+		{
+			PreserveReferencesHandling = PreserveReferencesHandling.None,
+			ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+			TypeNameHandling = TypeNameHandling.All,
+			ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+		};
+
+		public AnonymizerPage(Anonymizer anonymizer)
+		{
+			_anonymizer = anonymizer;
+			_serializedAnonymizer = JsonConvert.SerializeObject(anonymizer, _serializerSettings);
+			Title = anonymizer.DisplayText;
+
+			StackLayout contentLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				Children =
+				{
+					new Label
+					{
+						Text = Title,
+						FontSize = 20,
+						HorizontalOptions = LayoutOptions.CenterAndExpand
+					}
+				}
+			};
+
+			foreach (StackLayout stack in UiProperty.GetPropertyStacks(anonymizer))
+			{
+				contentLayout.Children.Add(stack);
+			}
+
+			Button okayButton = new Button()
+			{
+				Text = "OK",
+				FontSize = 20,
+				HorizontalOptions = LayoutOptions.FillAndExpand
+			};
+
+			Button cancelButton = new Button()
+			{
+				Text = "Cancel",
+				FontSize = 20,
+				HorizontalOptions = LayoutOptions.FillAndExpand
+			};
+
+			okayButton.Clicked += async (o, e) =>
+			{
+				try
+				{
+					if (anonymizer.Validate(out string errorMessage))
+					{
+						await Navigation.PopModalAsync(true);
+					}
+					else
+					{
+						await DisplayAlert(anonymizer.DisplayText, errorMessage, "OK");
+					}
+				}
+				catch (Exception error)
+				{
+					await DisplayAlert(anonymizer.DisplayText, error.Message, "OK");
+				}
+			};
+
+			cancelButton.Clicked += async (o, e) =>
+			{
+				JsonConvert.PopulateObject(_serializedAnonymizer, anonymizer, _serializerSettings);
+
+				await Navigation.PopModalAsync(true);
+			};
+
+			StackLayout buttonLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Children = { okayButton, cancelButton }
+			};
+
+			contentLayout.Children.Add(buttonLayout);
+
+			Content = contentLayout;
+		}
+
+		protected override bool OnBackButtonPressed()
+		{
+			if (_anonymizer.Validate(out string errorMessage) == false)
+			{
+				SensusContext.Current.MainThreadSynchronizer.ExecuteThreadSafe(async () =>
+				{
+					await DisplayAlert(_anonymizer.DisplayText, errorMessage, "OK");
+				});
+
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/Sensus.Shared/UI/ProbePage.cs
+++ b/Sensus.Shared/UI/ProbePage.cs
@@ -304,6 +304,29 @@ namespace Sensus.UI
                         probe.Protocol.JsonAnonymizer.SetAnonymizer(anonymizableProperty, selectedAnonymizer);
                     };
 
+					anonymizerPicker.Unfocused += async (o, e) =>
+					{
+						if (anonymizerPicker.SelectedIndex > 0)
+						{
+							Anonymizer selectedAnonymizer = anonymizableAttribute.AvailableAnonymizers[anonymizerPicker.SelectedIndex - 1];
+
+							if (UiProperty.HasUiProperties(selectedAnonymizer))
+							{
+								AnonymizerPage anonymizerPage = new AnonymizerPage(selectedAnonymizer);
+
+								anonymizerPage.Disappearing += (o2, e2) =>
+								{
+									if (selectedAnonymizer.IsValid == false)
+									{
+										anonymizerPicker.SelectedIndex = 0;
+									}
+								};
+
+								await Navigation.PushModalAsync(anonymizerPage);
+							}
+						}
+					};
+
                     // set the picker's index to the current anonymizer (or "Do Not Anonymize" if there is no current)
                     Anonymizer currentAnonymizer = probe.Protocol.JsonAnonymizer.GetAnonymizer(anonymizableProperty);
                     int currentIndex = 0;

--- a/Sensus.Shared/UI/UiProperties/UiProperty.cs
+++ b/Sensus.Shared/UI/UiProperties/UiProperty.cs
@@ -42,7 +42,9 @@ namespace Sensus.UI.UiProperties
 
             // For some reason, PropertyInfo.GetCustomAttributes doesn't return the UiProperty attribute placed on abstract 
             // properties that are overridden, so we have to navigate the inheritance tree to search for attributes.
-
+			// bzd3y: This is probably due to Inherited not being set to true in the [AttributeUsage] attribute above. The
+			// code below would probably be unnecessary if that was done. I'm not changing anything, but this can be a
+			// reminder of a possible future change.
             UiProperty attribute = property.GetCustomAttribute<UiProperty>();
 
             if (attribute == null)
@@ -63,6 +65,13 @@ namespace Sensus.UI.UiProperties
                 return attribute;
             }
         }
+
+		public static bool HasUiProperties(object o)
+		{
+			return o.GetType()
+				 .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+				 .Any(x => UiProperty.GetUiPropertyAttribute(x) != null);
+		}
 
         /// <summary>
         /// Gets a list of StackLayout objects associated with properties in an object that have been 


### PR DESCRIPTION
#893 Regex anonymizer has been added. I only put it on the keystroke probe at this point. The default replacement character is the FULL BLOCK Unicode character (█) commonly used for redacting text.