### PR TITLE
#862 timer input, set to complete

### DIFF
--- a/Sensus.Shared/UI/Inputs/TimerInput.cs
+++ b/Sensus.Shared/UI/Inputs/TimerInput.cs
@@ -102,6 +102,8 @@ namespace Sensus.UI.Inputs
 					{
 						_stopButton.IsEnabled = false;
 					}
+
+					Complete = true;
 				}
 
 				if (_elapsedTime % DISPLAY_PRECISION == 0)


### PR DESCRIPTION
#862 Looks like the timer input wasn't getting set to complete when the timer elapsed, only when the user stopped it.