### PR TITLE
Healthkit

### DIFF
--- a/Sensus.iOS.Shared/Probes/User/Health/iOSHealthKitSamplingProbe.cs
+++ b/Sensus.iOS.Shared/Probes/User/Health/iOSHealthKitSamplingProbe.cs
@@ -18,6 +18,8 @@ using System.Collections.Generic;
 using Sensus;
 using HealthKit;
 using System.Threading.Tasks;
+using Foundation;
+using System.Linq;
 
 namespace Sensus.iOS.Probes.User.Health
 {
@@ -57,6 +59,11 @@ namespace Sensus.iOS.Probes.User.Health
                     {
                         if (error == null)
                         {
+                            if (_queryAnchor == 0 && samples.Length > 0)
+                            {
+                                samples = new[] { samples.Last() };
+                            }
+
                             foreach (HKSample sample in samples)
                             {
                                 Datum datum = ConvertSampleToDatum(sample);

--- a/Sensus.iOS.Shared/Probes/User/Health/iOSHealthKitSamplingProbe.cs
+++ b/Sensus.iOS.Shared/Probes/User/Health/iOSHealthKitSamplingProbe.cs
@@ -40,7 +40,7 @@ namespace Sensus.iOS.Probes.User.Health
         public iOSHealthKitSamplingProbe(HKObjectType objectType)
             : base(objectType)
         {
-            _queryAnchor = 0;
+            //_queryAnchor = 0;
         }
 
         protected override Task<List<Datum>> PollAsync(CancellationToken cancellationToken)
@@ -51,7 +51,6 @@ namespace Sensus.iOS.Probes.User.Health
             Exception exception = null;
 
             HealthStore.ExecuteQuery(new HKAnchoredObjectQuery(ObjectType as HKSampleType, null, (nuint)_queryAnchor, nuint.MaxValue, new HKAnchoredObjectResultHandler2(
-                
                 (query, samples, newQueryAnchor, error) =>
                 {
                     try

--- a/Sensus.iOS.Shared/Probes/User/Health/iOSHealthKitSamplingProbe.cs
+++ b/Sensus.iOS.Shared/Probes/User/Health/iOSHealthKitSamplingProbe.cs
@@ -59,7 +59,7 @@ namespace Sensus.iOS.Probes.User.Health
                     {
                         if (error == null)
                         {
-                            if (_queryAnchor == 0 && samples.Length > 0)
+                            if (_queryAnchor == 0 && samples.Length > 1)
                             {
                                 samples = new[] { samples.Last() };
                             }

--- a/Sensus.iOS.Shared/Probes/User/Health/iOSHealthKitSamplingProbe.cs
+++ b/Sensus.iOS.Shared/Probes/User/Health/iOSHealthKitSamplingProbe.cs
@@ -42,7 +42,7 @@ namespace Sensus.iOS.Probes.User.Health
         public iOSHealthKitSamplingProbe(HKObjectType objectType)
             : base(objectType)
         {
-            //_queryAnchor = 0;
+
         }
 
         protected override Task<List<Datum>> PollAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
#764 Instead of starting from the protocol start time, I think the problem was actually that the query anchor was being set to 0 in the iOSHealthKitSamplingProbe's constructor so it was losing its progress and starting from 0 each time the probe was constructed. The query anchor was being serialized with the rest of the probe's properties, but that value was being overwritten by the constructor and was causing the probe to get all samples the first time the probe polled after being constructed. A predicate to query for after the Protocol start time could still be added, but I think this issue with the query anchor should still be fixed, otherwise every time it polls it is going to get all samples after the Protocol start time.

When the query anchor is 0, on the first poll, I made the probe only take the last sample if there were multiple, so it doesn't get all samples the first time, only the last one the user had entered.

I was afraid Protocol start time would cause the probe to not find anything the user had entered if they had only entered it before they were running the protocol. But maybe that is the desired behavior and in that case a predicate could be added to the query.



